### PR TITLE
Remove sandbox keys 12 factors

### DIFF
--- a/h_mac_helper.rb
+++ b/h_mac_helper.rb
@@ -45,8 +45,8 @@ class HMacHelper
       
       def self.aurora_api(p, method)
       host = "api-sandbox.aurorasolar.com"
-      aurora_api_key = "bcc68198-b5b5-42ad-a34e-f99ba462d102"
-      aurora_api_secret = "e412286f-76d6-40f3-b4a5-1cb4992651e4"
+      aurora_api_key = ENV['AURORA_API_KEY']
+      aurora_api_secret = ENV['AURORA_API_SECRET']
 
             # Plain script to send a sampel request to the API
             http_verb = "#{method}"


### PR DESCRIPTION
Remove sandbox keys and apply 12 factor.

Brijesh - Please review https://12factor.net/ for useful tips on  methodology for building software-as-a-service apps specifically see https://12factor.net/config which covers storing config values in the environment.

I recommend making all your repos private until they are sanitized and values that should not be shared publicly are removed. I made mistakes before with committing secrets to public repos it can be painful - this is a key principle to implement.
